### PR TITLE
Parameter jump example to adress #46

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -216,11 +216,11 @@ The following is a list of example scripts that may help you with specific probl
 
 * `Mackey–Glass with Jumps <https://github.com/neurophysik/jitcdde/blob/master/examples/mackey_glass_jump.py>`_ shows how to use the `jump` method.
 
-* `Simple Neutral <https://github.com/neurophysik/jitcdde/blob/master/examples/simple_neutral.py>`_ and `Neutral <https://github.com/neurophysik/jitcdde/blob/master/examples/simple_neutral.py>`_ show how to implement **neutral DDES**. The latter additionally shows how to optimise a DDE with **repeating delays**, making it considerably faster.
+* `Simple Neutral <https://github.com/neurophysik/jitcdde/blob/master/examples/simple_neutral.py>`_ and `Neutral <https://github.com/neurophysik/jitcdde/blob/master/examples/neutral.py>`_ show how to implement **neutral DDES**. The latter additionally shows how to optimise a DDE with **repeating delays**, making it considerably faster.
 
-* If you want to have **input or time-dependent parameters**, there are several options depending on the details of your problem:
+* If you want to have **input or time-dependent parameters**, there are several options depending on the details of your problem, exemplified in `this toy problem <https://github.com/neurophysik/jitcdde/blob/master/examples/mackey_glass_parameter_jump.py>`_:
 
-  * If you want a parameter to be a straightforward function of time, you can just implement this symbolically directly in the derivative.. For an example, see the “regular implementation” `here <https://github.com/neurophysik/jitcdde/blob/master/examples/sunflower_callback.py>`_.
+  * If you want a parameter to be a straightforward function of time, you can just implement this symbolically directly in the derivative. For an example, see the “regular implementation” `here <https://github.com/neurophysik/jitcdde/blob/master/examples/sunflower_callback.py>`_.
   * If you want a parameter to change its value at a small number of time points (jumps), you can use the techniques outlined `here <https://jitcde-common.readthedocs.io/en/latest/#conditionals>`_, i.e., either use `jitcxde_common.conditional` to approximate a step function in time or change a control parameter at the desired time point (and then `adjust_diff`).
   * For complex time dependencies, you can use `jitcdde_input <https://jitcdde.rtfd.io#input>`_ 
     `This example <https://github.com/neurophysik/jitcdde/blob/master/examples/data_input.py>`_ demonstrates how to use this.

--- a/examples/mackey_glass_parameter_jump.py
+++ b/examples/mackey_glass_parameter_jump.py
@@ -1,0 +1,174 @@
+"""
+The following are a set of examples that implement the Mackey-Glass system 
+with a jump in the value of a parameter. Here we will change the value of β 
+from β0 to β1 at time t0. 
+
+The result of all the methods is basically identical and they range from the 
+most straightforward to more involved ones. Choose whichever one suits your 
+usecase. 
+    1. Integrating two separate models with diferent β values
+    2. Use β as a control parameter for a system amd modify its value midway 
+    through the integration
+    3. Use jitcdde.input
+    4. Use jitcxde_common.conditional
+    5. Use callbacks to define our own conditional
+    
+Note that if the parameter that needs to jump is the delay, you'll need to 
+manually set max_delay when defining the integrator in cases 2-5.
+"""
+
+### Makey-Glass with time-dependent parameter
+
+import numpy as np
+from jitcdde import y, t, jitcdde
+from matplotlib.pyplot import subplots
+
+# Defining parameters
+# --------------
+
+τ = 15
+n = 10
+β0 = 0.25
+β1 = 0.4
+γ = 0.1
+
+t0 = 400
+dt = 1
+tf = 800
+
+# 1. Running separate models with the initial and final parameter value
+# --------------
+
+# Create a function to easily make a model with different values for β
+def make_model(β):
+    return [ β * y(0,t-τ) / (1 + y(0,t-τ)**n) - γ*y(0) ]
+
+# First run a model with β0 and integrate it to t0.
+DDE0 = jitcdde(make_model(β0))
+DDE0.constant_past(1)
+DDE0.adjust_diff()
+times0 = np.arange(0, t0, dt)
+data = [DDE0.integrate(t) for t in times0]
+
+# Create a new model using β1 and set its past to the last state of the other model
+# We use adjust_diff to handle the discontinuities that arise from the change in β
+DDE1 = jitcdde(make_model(β1))
+DDE1.add_past_points(DDE0.get_state())
+DDE1.adjust_diff()
+times1 = np.arange(t0, tf, dt)
+data = np.vstack( data + [DDE1.integrate(t) for t in times1])
+
+# Plot
+fig, ax = subplots()
+ax.plot(np.hstack((times0, times1)), data)
+ax.set_title('two separate models')
+
+
+# 2. Using a control parameter we modify mid-run
+# --------------
+
+from symengine import Symbol
+
+# Create the model with β being a symbol instead of having a value, and integrate it up to t0
+β = Symbol('b')
+f = [ β * y(0,t-τ) / (1 + y(0,t-τ)**n) - γ*y(0) ]
+
+# Run the model with βas its contorl parameter
+DDE = jitcdde(f, control_pars=[β])
+DDE.constant_past(1)
+DDE.set_parameters(β0)
+DDE.adjust_diff()
+
+times0 = np.arange(0, t0, dt)
+data = [DDE.integrate(t) for t in times0]
+
+# Set the parameter to a new value, adjust_diff and integrate the rest of the way
+times1 = np.arange(t0, tf, dt)
+DDE.set_parameters(β1)
+DDE.adjust_diff()
+data = np.vstack( data + [DDE.integrate(t) for t in times1])
+
+# Plot
+fig, ax = subplots()
+ax.plot(np.hstack((times0, times1)), data)
+ax.set_title('contorl parameter')
+
+
+# 3. Using input to modify the parameter mid-run
+# --------------
+
+from jitcdde import jitcdde_input, input
+from chspy import CubicHermiteSpline
+
+# Define how the parameter changes over time and put that information into a spline
+input_times = np.arange(0, tf)
+parameter_over_time = lambda t: β0 if t<t0 else β1
+parameter_spline = CubicHermiteSpline(n=1)
+parameter_spline.from_function(parameter_over_time, times_of_interest = input_times)
+
+# Defining Dynamics 
+β = input(0)
+f = [ β * y(0,t-τ) / (1 + y(0,t-τ)**n) - γ*y(0) ]
+
+# Create and integrate the model all the  way to the end, input handles the 
+# change in the value midway through the integration
+DDE = jitcdde_input(f, parameter_spline)
+DDE.constant_past(1)
+DDE.adjust_diff()
+times = DDE.t + np.arange(0, input_times[-1])
+data = np.vstack([DDE.integrate(time) for time in times])
+
+# Plot
+fig, ax = subplots()
+ax.plot(np.hstack((times0, times1)), data)
+ax.set_title('input')
+
+
+# 4. Using jitcxde_common.conditional to approjimate a jump
+# --------------
+
+from jitcxde_common import conditional
+
+# Define how the parameter changes over time and define the system dynamics
+β = conditional(t, t0, β0, β1)
+f = [ β * y(0,t-τ) / (1 + y(0,t-τ)**n) - γ*y(0) ]
+
+# Create and integrate the model all the  way to the end, conditional handles 
+# the change in the value midway through the integration
+DDE = jitcdde_input(f, parameter_spline)
+DDE.constant_past(1)
+DDE.adjust_diff()
+times = DDE.t + np.arange(0, tf)
+data = np.vstack([DDE.integrate(time) for time in times])
+
+# Plot
+fig, ax = subplots()
+ax.plot(times, data)
+ax.set_title('conditional')
+
+# 5. Writing the jump ourselves using a callback
+# --------------
+
+from symengine import Function
+
+# Define the the python function that will handle the jump and the symengine 
+# symbol corresponding to the parameter, which this time is a Function
+β = Function('param_jump')
+def param_jump_callback(y, t):
+    return β0 if t<t0 else β1
+
+# Define the dynamics of the system, β is now an explicit function of time
+f = [ β(t) * y(0,t-τ) / (1 + y(0,t-τ)**n) - γ*y(0) ]
+
+# Create and integrate the model all the way to the end, the callback handles 
+# the change in the value midway through the integration
+DDE = jitcdde(f, callback_functions=[ (β, param_jump_callback, 1) ])
+DDE.constant_past(1)
+DDE.adjust_diff()
+times = DDE.t + np.arange(0, tf)
+data = np.vstack([DDE.integrate(time) for time in times])
+
+# Plot
+fig, ax = subplots()
+ax.plot(times, data)
+ax.set_title('callback')


### PR DESCRIPTION
In #46 we discussed adding an example that implements all the different ways we could come up with to make a parameter have a jump at a given time point during integration. I've done

1. Two separate integrations
2. Use control parameters
3. Use input
4. Use conditional
5. Use callbacks

I've also added a line to the docu pointing to this example, but didn't write a full documentation section, i don't think it fits there. The code is decently documented, but we can always document more, of course. 

What I'm still missing is comments on the different methods: when to prefer one over another? For instance, I'd never recomend 1 over 2 since they are basically the same thing, but one of them requires twice as much compilation. I read (from you) that callbacks tend to be slow, so I don't know when  to recommend them over input or conditional. And I have no idea how those two compare to one another and to 2. Of course, for this toy example, any of these choices would be good enough, but having an expert comment to orient newcomers (and to orient me as well) would be useful. What advantages and limitations may each example have?