### PR TITLE
Pass tests with latest numpy

### DIFF
--- a/tests/test_jitcdde.py
+++ b/tests/test_jitcdde.py
@@ -431,10 +431,9 @@ class TestInput(unittest.TestCase):
 			for l in range(1,n)
 			for combo in combinations(range(n),l)
 		]
-		
-		for combo in np.random.choice(combos,3,replace=False):
-			combo = [3,5]
-			substitutions = { y(i):input(i) for i in combo }
+
+		for icombo in np.random.choice(len(combos),3,replace=False):
+			substitutions = { y(i): input(i) for i in combos[icombo] }
 			f_input = [expression.subs(substitutions) for expression in f]
 			DDE = jitcdde_input(f,self.result)
 			DDE.set_integration_parameters(**test_parameters)


### PR DESCRIPTION
This test was failing for me locally due to the fact that `np.random.choice` no longer works with standard Python lists. It tried to transform `combos` into an `ndarray` and failed because the entries are not the same size.

Not sure in what version of numpy this changed, but it doesn't work on 2.1.2.